### PR TITLE
Add odh-ai-fifth-demo to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -56,3 +56,6 @@ map:
   odh-workload-variant-autoscaler-controller:
     src: config
     dest: wva
+  odh-ai-fifth-demo:
+    src: config/manifests
+    dest: opt/manifests/odh-ai-fifth-demo


### PR DESCRIPTION
Adds 'odh-ai-fifth-demo' to the operator manifests config map.

Component: odh-ai-fifth-demo
Manifest source path: config/manifests
Manifest dest path:   opt/manifests/odh-ai-fifth-demo
Upstream repo: https://github.com/rhoai-rhtap/odh-ai-fifth-demo @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHODS-14227

**File changed:**
- `build/manifests-config.yaml` — added `odh-ai-fifth-demo` entry under `map:`