### PR TITLE
Add odh-ai-sixth-demo to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -59,3 +59,6 @@ map:
   odh-ai-fifth-demo:
     src: config/manifests
     dest: opt/manifests/odh-ai-fifth-demo
+  odh-ai-sixth-demo:
+    src: config/manifests
+    dest: opt/manifests/odh-ai-sixth-demo


### PR DESCRIPTION
Adds 'odh-ai-sixth-demo' to the operator manifests config map.

Component: odh-ai-sixth-demo
Manifest source path: config/manifests
Manifest dest path:   opt/manifests/odh-ai-sixth-demo
Upstream repo: https://github.com/rhoai-rhtap/odh-ai-sixth-demo @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHODS-14227

**File changed:**
- `build/manifests-config.yaml` — added `odh-ai-sixth-demo` entry under `map:`